### PR TITLE
Fix output formatting

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron:  '55 * * * *'
   workflow_dispatch:
+  pull_request:
 
 jobs:
   generate:
@@ -26,4 +27,5 @@ jobs:
         run: bot 
 
       - name: Commit
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -18,8 +18,12 @@ jobs:
         with:
           go-version: '1.20'
 
+      - name: Build
+        working-directory: ./bot
+        run: go install -v ./...
+
       - name: Next Prime
-        run: go run main.go
+        run: bot 
 
       - name: Commit
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+defaults:
+  run:
+    working-directory: ./bot
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/bot/go.mod
+++ b/bot/go.mod
@@ -1,11 +1,8 @@
-module github.com/fardog/primeweb
+module github.com/fardog/primeweb/bot
 
 go 1.20
 
-require (
-	github.com/fardog/primebot v0.0.0-20230302055454-02e5473e2fe2
-	golang.org/x/text v0.6.0
-)
+require github.com/fardog/primebot v0.0.0-20230302055454-02e5473e2fe2
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect

--- a/bot/go.sum
+++ b/bot/go.sum
@@ -5,8 +5,6 @@ github.com/dghubble/go-twitter v0.0.0-20221104224141-912508c3888b h1:XQu6o3AwJx/
 github.com/dghubble/go-twitter v0.0.0-20221104224141-912508c3888b/go.mod h1:B0/qdW5XUupJvcsx40hnVbfjzz9He5YpYXx6eVVdiSY=
 github.com/dghubble/sling v1.4.1 h1:AxjTubpVyozMvbBCtXcsWEyGGgUZutC5YGrfxPNVOcQ=
 github.com/dghubble/sling v1.4.1/go.mod h1:QoMB1KL3GAo+7HsD8Itd6S+6tW91who8BGZzuLvpOyc=
-github.com/fardog/primebot v0.0.0-20230206051320-79222f68116f h1:NWuIH3MHRNhyn0uYqWOCSwDIbyljjTFadFjlp84O1Qs=
-github.com/fardog/primebot v0.0.0-20230206051320-79222f68116f/go.mod h1:x2FAgiWF8oe5ZN6TbFMkqCtCkhH6IOLaA9ve+cAOMyw=
 github.com/fardog/primebot v0.0.0-20230302055454-02e5473e2fe2 h1:TOHJLTM+4GCAA3+9CwVRQDeqPMb4xBunCeFs0vf8ONo=
 github.com/fardog/primebot v0.0.0-20230302055454-02e5473e2fe2/go.mod h1:x2FAgiWF8oe5ZN6TbFMkqCtCkhH6IOLaA9ve+cAOMyw=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
@@ -21,7 +19,5 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
-golang.org/x/text v0.6.0 h1:3XmdazWV+ubf7QgHSTWeykHOci5oeekaGJBLkrkaw4k=
-golang.org/x/text v0.6.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/bot/main.go
+++ b/bot/main.go
@@ -274,6 +274,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	fmt.Printf("posted latest prime %s", next)
 }
 
 func reverse(s string) (result string) {

--- a/bot/main.go
+++ b/bot/main.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/fardog/primebot"
-	"golang.org/x/text/language"
-	"golang.org/x/text/message"
 )
 
 type fileInterface struct {
@@ -69,8 +67,6 @@ func (t *templateWriter) Post(ctx context.Context, status *big.Int) error {
 	}
 	defer out.Close()
 
-	p := message.NewPrinter(language.English)
-
 	type templateData struct {
 		Date      string
 		Integer   string
@@ -84,7 +80,7 @@ func (t *templateWriter) Post(ctx context.Context, status *big.Int) error {
 	tpl.Execute(out, templateData{
 		t.now.UTC().Format(time.RFC3339),
 		status.Text(10),
-		p.Sprintf("%d", status),
+		format(status),
 	})
 
 	return nil
@@ -278,4 +274,25 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func reverse(s string) (result string) {
+	for _, r := range s {
+		result = string(r) + result
+	}
+	return
+}
+
+func format(i *big.Int) string {
+	var f string
+	s := reverse(i.Text(10))
+	for i, r := range s {
+		if i != 0 && i%3 == 0 {
+			f = f + "," + string(r)
+			continue
+		}
+		f = f + string(r)
+	}
+
+	return reverse(f)
 }

--- a/bot/main_test.go
+++ b/bot/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestFormat(t *testing.T) {
+	cases := map[*big.Int]string{
+		big.NewInt(1):          "1",
+		big.NewInt(12):         "12",
+		big.NewInt(123):        "123",
+		big.NewInt(1234):       "1,234",
+		big.NewInt(12345):      "12,345",
+		big.NewInt(123456):     "123,456",
+		big.NewInt(1234567):    "1,234,567",
+		big.NewInt(12345678):   "12,345,678",
+		big.NewInt(123456789):  "123,456,789",
+		big.NewInt(1234567890): "1,234,567,890",
+	}
+
+	for c, e := range cases {
+		if a := format(c); a != e {
+			t.Errorf("expected %s, got %s", e, a)
+		}
+	}
+}


### PR DESCRIPTION
as more files end up in the go working directory, there've been issues with golang tooling running out of memory since it's trying to evaluate the entire tree. this moves the bot into its own directory to avoid that.

this also fixes a bug i introduced where formatting was no longer being correctly applied since we moved from uint64 -> big.Int, handling this now with a custom formatter. adds tests for that formatter. more are needed but this is fine for now.